### PR TITLE
Pass parsed request-URL into the run-method

### DIFF
--- a/examples/custom-server-hapi/next-wrapper.js
+++ b/examples/custom-server-hapi/next-wrapper.js
@@ -2,7 +2,7 @@ const pathWrapper = (app, pathName, opts) => ({ raw, query }, hapiReply) =>
 app.renderToHTML(raw.req, raw.res, pathName, query, opts)
 .then(hapiReply)
 
-const defaultHandlerWrapper = app => ({ raw }, hapiReply) =>
-app.run(raw.req, raw.res)
+const defaultHandlerWrapper = app => ({ raw, url }, hapiReply) =>
+app.run(raw.req, raw.res, url)
 
 module.exports = { pathWrapper, defaultHandlerWrapper }


### PR DESCRIPTION
The [`Server#run`](https://github.com/zeit/next.js/blob/master/server/index.js#L133)-method expects the parsed request-URL. Since this is currently missing the Hapi example errors with …

```
(node:61994) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): TypeError: Cannot read property 'pathname' of undefined
```